### PR TITLE
Add Geiser support, ElDoc color proposition

### DIFF
--- a/gotham-theme.el
+++ b/gotham-theme.el
@@ -225,6 +225,9 @@ depending on DISPLAY for keys which are either :foreground or
    (ediff-odd-diff-C :background base2)
    ;(ediff-odd-diff-Ancestor)
 
+   ;; eldoc
+   (eldoc-highlight-function-argument :foreground orange :weight bold)
+
    ;; eshell
    (eshell-prompt :foreground yellow :weight bold)
    (eshell-ls-archive :foreground magenta)
@@ -450,6 +453,13 @@ depending on DISPLAY for keys which are either :foreground or
    (enh-ruby-string-delimiter-face :foreground green)
    (erm-syn-errline :foreground red)
    (erm-syn-warnline :foreground orange)
+
+   ;; geiser
+   (geiser-font-lock-autodoc-current-arg :foreground orange)
+   (geiser-font-lock-autodoc-identifier :foreground magenta)
+   (geiser-font-lock-doc-link :foreground blue :underline t)
+   (geiser-font-lock-error-link :foreground cyan :underline t)
+   (geiser-font-lock-xref-link :foreground green :underline t)
 
    ;; helm
    (helm-bookmark-addressbook :foreground orange)


### PR DESCRIPTION
Currently ElDoc displays function arguments in bold only, that's a little bit undistinguishable for me so I changed it to bold orange, Geiser follows this as well. Related to #25 