### PR TITLE
Swap orange with base4 on Info-quoted

### DIFF
--- a/gotham-theme.el
+++ b/gotham-theme.el
@@ -333,7 +333,7 @@ depending on DISPLAY for keys which are either :foreground or
    (ido-subdir :foreground red)
 
    ;; info
-   (Info-quoted :inherit italic :foreground orange :weight bold)
+   (Info-quoted :foreground base4 :weight bold)
    (info-menu-header :foreground green :weight bold :height 1.4 )
    (info-menu-star :foreground red)
    (info-node :inherit italic :foreground base6 :weight bold)

--- a/gotham-theme.el
+++ b/gotham-theme.el
@@ -333,7 +333,7 @@ depending on DISPLAY for keys which are either :foreground or
    (ido-subdir :foreground red)
 
    ;; info
-   (Info-quoted :foreground base4 :weight bold)
+   (Info-quoted :inherit font-lock-constant-face)
    (info-menu-header :foreground green :weight bold :height 1.4 )
    (info-menu-star :foreground red)
    (info-node :inherit italic :foreground base6 :weight bold)


### PR DESCRIPTION
When info links pile up things get too orange (emacs-25 change).