### PR TITLE
Fix rainbow-delimiters

### DIFF
--- a/gotham-theme.el
+++ b/gotham-theme.el
@@ -855,14 +855,14 @@ depending on DISPLAY for keys which are either :foreground or
 
    ;; rainbow-delimiters
    (rainbow-delimiters-depth-1-face :foreground base6)
-   (rainbow-delimiters-depth-2-face :inherit outline-1)
-   (rainbow-delimiters-depth-3-face :inherit outline-2)
-   (rainbow-delimiters-depth-4-face :inherit outline-3)
-   (rainbow-delimiters-depth-5-face :inherit outline-4)
-   (rainbow-delimiters-depth-6-face :inherit outline-5)
-   (rainbow-delimiters-depth-7-face :inherit outline-6)
-   (rainbow-delimiters-depth-8-face :inherit outline-7)
-   (rainbow-delimiters-depth-9-face :inherit outline-8)
+   (rainbow-delimiters-depth-2-face :foreground cyan)
+   (rainbow-delimiters-depth-3-face :foreground orange)
+   (rainbow-delimiters-depth-4-face :foreground magenta)
+   (rainbow-delimiters-depth-5-face :foreground green)
+   (rainbow-delimiters-depth-6-face :foreground blue)
+   (rainbow-delimiters-depth-7-face :foreground yellow)
+   (rainbow-delimiters-depth-8-face :foreground violet)
+   (rainbow-delimiters-depth-9-face :foreground red)
    (rainbow-delimiters-unmatched-face :foreground base2 :background base6)
 
    ;; rst-mode


### PR DESCRIPTION
Inheritance from outline-mode doesn't work for some reason (colors are not applied at all), so I adjusted the colors a bit.