### PR TITLE
Fix visible leading stars

### DIFF
--- a/gotham-theme.el
+++ b/gotham-theme.el
@@ -871,7 +871,7 @@ depending on DISPLAY for keys which are either :foreground or
    (org-habit-ready-face :background green)
    (org-habit-ready-future-face :background green)
    (org-headline-done :foreground yellow)
-   (org-hide :background base0)
+   (org-hide :foreground base0)
    (org-latex-and-related :foreground orange)
    (org-scheduled :foreground green)
    (org-scheduled-previously :foreground orange)


### PR DESCRIPTION
With `org-hide-leading-stars` set to t, we need the foreground of the stars to match the background colour, otherwise the stars are not hidden. I believe this was a mistake.