### PR TITLE
Don't use red background in Gnus

### DIFF
--- a/gotham-theme.el
+++ b/gotham-theme.el
@@ -270,7 +270,7 @@ depending on DISPLAY for keys which are either :foreground or
    (gnus-header-subject :foreground base5)
    (gnus-x-face :foreground base0 :background base6)
    (gnus-signature :inherit italic :foreground blue)
-   (mm-uu-extract :foreground base6 :background red)
+   (mm-uu-extract :foreground green :background base1)
    (gnus-cite-1 :foreground base4)
    (gnus-cite-2 :foreground base5)
    (gnus-cite-3 :foreground base6)


### PR DESCRIPTION
Before: 
![two](https://cloud.githubusercontent.com/assets/85483/23790509/a00309a4-057f-11e7-8e44-d8700ca0d454.png)
After:
![one](https://cloud.githubusercontent.com/assets/85483/23790517/ad8e89c2-057f-11e7-869c-e5ed9ccdb4c5.png)

