### PR TITLE
Avoid org-block color clashes

### DIFF
--- a/gotham-theme.el
+++ b/gotham-theme.el
@@ -888,7 +888,7 @@ depending on DISPLAY for keys which are either :foreground or
    (org-agenda-done :foreground green)
    (org-agenda-restriction-lock :inherit highlight)
    (org-agenda-structure :foreground base5)
-   (org-block :foreground base5)
+   (org-block :foreground base7)
    (org-clock-overlay :inherit secondary-selection)
    (org-column :background base2)
    (org-column-title :inherit org-column :underline t)

--- a/gotham-theme.el
+++ b/gotham-theme.el
@@ -888,7 +888,7 @@ depending on DISPLAY for keys which are either :foreground or
    (org-agenda-done :foreground green)
    (org-agenda-restriction-lock :inherit highlight)
    (org-agenda-structure :foreground base5)
-   (org-block :foreground base7)
+   (org-block :inherit default)
    (org-clock-overlay :inherit secondary-selection)
    (org-column :background base2)
    (org-column-title :inherit org-column :underline t)


### PR DESCRIPTION
base5 clashes with a few other faces in the block. We could use base6, which would make it similar to how codes look in their respective modes. If we need block text to contrast with non-block text (which I think is a reasonable choice), then we could could use base7 instead, which is a little brighter, but is still close to the original.