### PR TITLE
Fix unreadable match highlight

### DIFF
--- a/gotham-theme.el
+++ b/gotham-theme.el
@@ -156,7 +156,7 @@ depending on DISPLAY for keys which are either :foreground or
    (warning :foreground orange)
 
    ;; search and highlighting
-   (match :background base5)
+   (match :background base4)
    (isearch :inverse-video t)
    (isearch-fail :foreground red)
    (lazy-highlight :foreground base2 :background yellow)


### PR DESCRIPTION
Before:
![region](https://cloud.githubusercontent.com/assets/85483/26275845/989410f0-3d6a-11e7-8f4d-3542d0b09a81.png)

After:
![region2](https://cloud.githubusercontent.com/assets/85483/26275850/9ca5f6ae-3d6a-11e7-8593-99b9f5b938e2.png)
