### PR TITLE
add realgud support

### DIFF
--- a/gotham-theme.el
+++ b/gotham-theme.el
@@ -974,6 +974,17 @@ depending on DISPLAY for keys which are either :foreground or
    (rainbow-delimiters-depth-9-face :foreground red)
    (rainbow-delimiters-unmatched-face :foreground base2 :background base6)
 
+   ;; realgud
+   (realgud-overlay-arrow1         :foreground green)
+   (realgud-overlay-arrow2         :foreground yellow)
+   (realgud-overlay-arrow3         :foreground orange)
+   (realgud-bp-enabled-face        :inherit error)
+   (realgud-bp-disabled-face       :inherit secondary-selection)
+   (realgud-bp-line-enabled-face   :foreground red)
+   (realgud-bp-line-disabled-face  :inherit secondary-selection)
+   (realgud-line-number            :inherit sml/line-number)
+   (realgud-backtrace-number       :inherit sml/line-number :weight bold)
+
    ;; rst-mode
    (rst-level-1 :background base2)
    (rst-level-2 :background base3)

--- a/gotham-theme.el
+++ b/gotham-theme.el
@@ -982,8 +982,8 @@ depending on DISPLAY for keys which are either :foreground or
    (realgud-bp-disabled-face       :inherit secondary-selection)
    (realgud-bp-line-enabled-face   :foreground red)
    (realgud-bp-line-disabled-face  :inherit secondary-selection)
-   (realgud-line-number            :inherit sml/line-number)
-   (realgud-backtrace-number       :inherit sml/line-number :weight bold)
+   (realgud-line-number            :foreground base5)
+   (realgud-backtrace-number       :inherit realgud-line-number :weight bold)
 
    ;; rst-mode
    (rst-level-1 :background base2)


### PR DESCRIPTION
The things to make realgud look pretty in gotham-them. But....
I'm not a graphic designer so feel free to adjust as appropriate

Things I tried: 

* Run realgud:cmdbuf-info-describe to look at org mode formatting
* run "bt" (backtrace) to look at how backtraces are formatted, say for gdb
* In a source shortkey mode buffer:
    - Step 3 times to look at 3 levels of fringe arrows colors
    - set a breakpoint
    - disable a breakpoint
    - enable a breakpoint


