### PR TITLE
Add base term colors

### DIFF
--- a/gotham-theme.el
+++ b/gotham-theme.el
@@ -417,6 +417,7 @@ depending on DISPLAY for keys which are either :foreground or
    (show-paren-mismatch :foreground base2 :background red :inverse-video nil)
 
    ;; term
+   (term :foreground base6 :background base0)
    (term-color-black :foreground base1 :background base1)
    (term-color-red :foreground red :background red)
    (term-color-green :foreground green :background green)


### PR DESCRIPTION
Weird things happen in `ansi-term` if you disable gotham, then enable a theme that defines a base term color (eg solarized-light), then disable that new theme and re-enable gotham.